### PR TITLE
Add functionality to level service

### DIFF
--- a/src/include/DataModelV2/LevelInstance.h
+++ b/src/include/DataModelV2/LevelInstance.h
@@ -7,10 +7,15 @@ class LevelInstance :
 public:
 	LevelInstance(void);
 	~LevelInstance(void);
+	bool HighScoreIsGood;
+	Enum::ActionType::Value TimerUpAction;
+	Enum::AffectType::Value TimerAffectsScore;
+	bool RunOnOpen;
 	float timer;
 	int score;
 	virtual std::vector<PROPGRIDITEM> getProperties();
 	std::string winMessage;
 	std::string loseMessage;
 	virtual void PropUpdate(LPPROPGRIDITEM &pItem);
+	void Step(SimTime sdt);
 };

--- a/src/include/DataModelV2/LevelInstance.h
+++ b/src/include/DataModelV2/LevelInstance.h
@@ -17,5 +17,9 @@ public:
 	std::string winMessage;
 	std::string loseMessage;
 	virtual void PropUpdate(LPPROPGRIDITEM &pItem);
+	void winCondition();
+	void loseCondition();
+	void pauseCondition();
+	void drawCondition();
 	void Step(SimTime sdt);
 };

--- a/src/include/Enum.h
+++ b/src/include/Enum.h
@@ -20,4 +20,16 @@ namespace Enum
 			Player = 7, KeyboardRight = 1, KeyboardLeft = 2, Joypad1 = 3, Joypad2 = 4, Chase = 5, Flee = 6, None = 0
 		};
 	}
+	namespace ActionType
+	{
+		enum Value {
+			Nothing = 0, Pause = 1, Lose = 2, Draw = 3, Win = 4
+		};
+	}
+	namespace AffectType
+	{
+		enum Value {
+			NoChange = 0, Increase = 1, Decrease = 2
+		};
+	}
 }

--- a/src/source/Application.cpp
+++ b/src/source/Application.cpp
@@ -323,6 +323,9 @@ void Application::onSimulation(RealTime rdt, SimTime sdt, SimTime idt) {
 
 	if(_dataModel->isRunning())
 	{
+		LevelInstance* Level = _dataModel->getLevel();
+		Level->Step(sdt);
+
 		// XplicitNgine Start
 		std::vector<PartInstance *> toDelete;
 		for(size_t i = 0; i < _dataModel->getWorkspace()->partObjects.size(); i++)

--- a/src/source/DataModelV2/LevelInstance.cpp
+++ b/src/source/DataModelV2/LevelInstance.cpp
@@ -1,3 +1,4 @@
+#include "DataModelV2/DataModelInstance.h"
 #include "DataModelV2/LevelInstance.h"
 
 LevelInstance::LevelInstance(void)
@@ -16,6 +17,61 @@ LevelInstance::~LevelInstance(void)
 }
 
 
+static TCHAR* strActionType(int option)
+{
+	switch(option)
+	{
+		case Enum::ActionType::Nothing:
+			return "Nothing";
+		case Enum::ActionType::Pause:
+			return "Pause";
+		case Enum::ActionType::Lose:
+			return "Lose";
+		case Enum::ActionType::Draw:
+			return "Draw";
+		case Enum::ActionType::Win:
+			return "Win";
+	}
+	return "Nothing";
+}
+
+static Enum::ActionType::Value EnumActionType(TCHAR* option)
+{
+	if(strcmp("Nothing", option) == 0)
+		return Enum::ActionType::Nothing;
+	if(strcmp("Pause", option) == 0)
+		return Enum::ActionType::Pause;
+	if(strcmp("Lose", option) == 0)
+		return Enum::ActionType::Lose;
+	if(strcmp("Draw", option) == 0)
+		return Enum::ActionType::Draw;
+	return Enum::ActionType::Win;
+}
+
+static TCHAR* strAffectType(int option)
+{
+	switch(option)
+	{
+		case Enum::AffectType::NoChange:
+			return "NoChange";
+		case Enum::AffectType::Increase:
+			return "Increase";
+		case Enum::AffectType::Decrease:
+			return "Decrease";
+	}
+	return "NoChange";
+}
+
+static Enum::AffectType::Value EnumAffectType(TCHAR* option)
+{
+	if(strcmp("NoChange", option) == 0)
+		return Enum::AffectType::NoChange;
+	if(strcmp("Increase", option) == 0)
+		return Enum::AffectType::Increase;
+	return Enum::AffectType::Decrease;
+}
+
+
 char timerTxt[12];
 char scoreTxt[12];
 std::vector<PROPGRIDITEM> LevelInstance::getProperties()
@@ -29,12 +85,28 @@ std::vector<PROPGRIDITEM> LevelInstance::getProperties()
 		"The message that shows when the player wins.",
 		(LPARAM)winMessage.c_str(),
 		PIT_EDIT));
+
 	properties.push_back(createPGI("Messages",
 		"LoseMessage",
 		"The message that shows when the player loses.",
 		(LPARAM)loseMessage.c_str(),
 		PIT_EDIT));
 
+	properties.push_back(createPGI(
+		"Gameplay",
+		"HighScoreIsGood",
+		"Some temporary string here",
+		(LPARAM)HighScoreIsGood,
+		PIT_CHECK
+		));
+
+	properties.push_back(createPGI(
+		"Gameplay",
+		"RunOnOpen",
+		"Some temporary string here",
+		(LPARAM)RunOnOpen,
+		PIT_CHECK
+		));
 
 	sprintf_s(timerTxt, "%g", timer);
 	sprintf_s(scoreTxt, "%d", score);
@@ -43,11 +115,28 @@ std::vector<PROPGRIDITEM> LevelInstance::getProperties()
 		"The amount of time in seconds the player has to complete this level.\r\n\r\nPut 0 if time is limitless.",
 		(LPARAM)timerTxt,
 		PIT_EDIT));
+
 	properties.push_back(createPGI("Gameplay",
 		"InitialScoreValue",
 		"The amount of points the player starts with.",
 		(LPARAM)scoreTxt,
 		PIT_EDIT));
+
+		properties.push_back(createPGI("Gameplay",
+		"TimerUpAction",
+		"Some temporary string here",
+		(LPARAM)strActionType(TimerUpAction),
+		PIT_COMBO,
+		TEXT("Nothing\0Pause\0Lose\0Draw\0Win\0")
+		));
+
+		properties.push_back(createPGI("Gameplay",
+		"TimerAffectsScore",
+		"Some temporary string here",
+		(LPARAM)strAffectType(TimerAffectsScore),
+		PIT_COMBO,
+		TEXT("NoChange\0Increase\0Decrease\0")
+		));
 	return properties;
 }
 void LevelInstance::PropUpdate(LPPROPGRIDITEM &pItem)
@@ -68,6 +157,64 @@ void LevelInstance::PropUpdate(LPPROPGRIDITEM &pItem)
 	{
 		winMessage = (LPSTR)pItem->lpCurValue;
 	}
+	else if(strcmp(pItem->lpszPropName, "TimerUpAction") == 0)
+	{
+		TimerUpAction = EnumActionType((TCHAR*)pItem->lpCurValue);
+	}
+	else if(strcmp(pItem->lpszPropName, "TimerAffectsScore") == 0)
+	{
+		TimerAffectsScore = EnumAffectType((TCHAR*)pItem->lpCurValue);
+	}
+	else if(strcmp(pItem->lpszPropName, "HighScoreIsGood") == 0)
+	{
+		HighScoreIsGood = pItem->lpCurValue == TRUE;
+	}
+	else if(strcmp(pItem->lpszPropName, "RunOnOpen") == 0)
+	{
+		RunOnOpen = pItem->lpCurValue == TRUE;
+	}
 	else
 		Instance::PropUpdate(pItem);
+}
+
+void LevelInstance::Step(SimTime sdt)
+{
+	switch(TimerAffectsScore)
+	{
+		case Enum::AffectType::NoChange:
+			break;
+		case Enum::AffectType::Increase:
+			score += 1;
+			break;
+		case Enum::AffectType::Decrease:
+			if (score > 0)
+				score -= 1;
+			break;
+	}
+	if (timer >= 0.1f){
+		timer -= sdt;
+	}
+	else{
+		timer = 0.0f;
+		DataModelInstance* DataModel = (DataModelInstance*)getParent();
+		switch(TimerUpAction)
+		{
+			case Enum::ActionType::Nothing:
+				break;
+			case Enum::ActionType::Pause:
+				DataModel->toggleRun();
+				break;
+			case Enum::ActionType::Lose:
+				DataModel->setMessage(loseMessage);
+				DataModel->toggleRun();
+				break;
+			case Enum::ActionType::Draw:
+				DataModel->toggleRun();
+				break;
+			case Enum::ActionType::Win:
+				DataModel->setMessage(winMessage);
+				DataModel->toggleRun();
+				break;
+		}
+	}
 }

--- a/src/source/DataModelV2/LevelInstance.cpp
+++ b/src/source/DataModelV2/LevelInstance.cpp
@@ -177,6 +177,32 @@ void LevelInstance::PropUpdate(LPPROPGRIDITEM &pItem)
 		Instance::PropUpdate(pItem);
 }
 
+void LevelInstance::winCondition()
+{
+	DataModelInstance* DataModel = (DataModelInstance*)getParent(); //If level parent gets changed to something other than Datamodel it could cause nasty data corruption bugs
+	DataModel->setMessage(winMessage);
+	DataModel->toggleRun();
+}
+
+void LevelInstance::loseCondition()
+{
+	DataModelInstance* DataModel = (DataModelInstance*)getParent();
+	DataModel->setMessage(loseMessage);
+	DataModel->toggleRun();
+}
+
+void LevelInstance::pauseCondition()
+{
+	DataModelInstance* DataModel = (DataModelInstance*)getParent();
+	DataModel->toggleRun();
+}
+
+void LevelInstance::drawCondition()
+{
+	DataModelInstance* DataModel = (DataModelInstance*)getParent();
+	DataModel->toggleRun();
+}
+
 void LevelInstance::Step(SimTime sdt)
 {
 	switch(TimerAffectsScore)
@@ -196,24 +222,21 @@ void LevelInstance::Step(SimTime sdt)
 	}
 	else{
 		timer = 0.0f;
-		DataModelInstance* DataModel = (DataModelInstance*)getParent(); //If level parent gets changed to something other than Datamodel it could cause nasty data corruption bugs
 		switch(TimerUpAction)
 		{
 			case Enum::ActionType::Nothing:
 				break;
 			case Enum::ActionType::Pause:
-				DataModel->toggleRun();
+				pauseCondition();
 				break;
 			case Enum::ActionType::Lose:
-				DataModel->setMessage(loseMessage);
-				DataModel->toggleRun();
+				loseCondition();
 				break;
 			case Enum::ActionType::Draw:
-				DataModel->toggleRun();
+				drawCondition();
 				break;
 			case Enum::ActionType::Win:
-				DataModel->setMessage(winMessage);
-				DataModel->toggleRun();
+				winCondition();
 				break;
 		}
 	}

--- a/src/source/DataModelV2/LevelInstance.cpp
+++ b/src/source/DataModelV2/LevelInstance.cpp
@@ -191,12 +191,12 @@ void LevelInstance::Step(SimTime sdt)
 				score -= 1;
 			break;
 	}
-	if (timer >= 0.1f){
+	if (timer >= 0.1f){ //Due to timing used this could cause the number go into negatives for one step
 		timer -= sdt;
 	}
 	else{
 		timer = 0.0f;
-		DataModelInstance* DataModel = (DataModelInstance*)getParent();
+		DataModelInstance* DataModel = (DataModelInstance*)getParent(); //If level parent gets changed to something other than Datamodel it could cause nasty data corruption bugs
 		switch(TimerUpAction)
 		{
 			case Enum::ActionType::Nothing:


### PR DESCRIPTION
Adds: Timer, TimerUpAction and TimerAffectsScore
It also adds other gameplay properties such as RunOnOpen and HighScoreIsGood but aren't implemented
RunOnOpen isn't implemented because the functionality it relies on isn't in a complete state
HighScoreIsGood isn't implemented because its unknown what it does
