### PR TITLE
Added versioning file, Removed assemblyIdentity

### DIFF
--- a/Blocks3D.exe.manifest
+++ b/Blocks3D.exe.manifest
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-	<assemblyIdentity
-		version="0.0.106.2"
-		processorArchitecture="*"
-		name="Blocks3D.Blocks3D.Blocks3D"
-		type="win32"
-	/>
 	<dependency>
 		<dependentAssembly>
 			<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>

--- a/Blocks3D.vcproj
+++ b/Blocks3D.vcproj
@@ -740,6 +740,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\src\include\versioning.h"
+				>
+			</File>
+			<File
 				RelativePath=".\src\include\VS2005CompatShim.h"
 				>
 			</File>

--- a/Dialogs.rc
+++ b/Dialogs.rc
@@ -6,17 +6,7 @@
 #include <commctrl.h>
 #include <richedit.h>
 #include "src/include/resource.h"
-
-#define APP_GENER 0
-#define APP_MAJOR 0
-#define APP_MINOR 106
-#define APP_PATCH 4
-#define APP_VER_STRING APP_GENER.APP_MAJOR.APP_MINOR.APP_PATCH
-
-#define VER_PREFIX( N ) v##N
-#define HSTR( N ) #N
-#define STR( N ) HSTR( N )
-#define VER_STR( N ) STR( VER_PREFIX( N ) )
+#include "src/include/versioning.h"
 
 
 

--- a/src/include/versioning.h
+++ b/src/include/versioning.h
@@ -1,0 +1,23 @@
+#ifndef APP_GENER
+
+#define SNAPSHOT_VERSION
+
+#define APP_GENER 0
+#define APP_MAJOR 0
+#define APP_MINOR 107
+#define APP_PATCH 0
+#define APP_VER_STRING APP_GENER.APP_MAJOR.APP_MINOR.APP_PATCH
+
+
+#ifdef SNAPSHOT_VERSION
+#define VER_PREFIX( N ) v##N-SNAPSHOT
+#else
+#define VER_PREFIX( N ) v##N
+#endif
+
+
+#define HSTR( N ) #N
+#define STR( N ) HSTR( N )
+#define VER_STR( N ) STR( VER_PREFIX( N ) )
+
+#endif


### PR DESCRIPTION
Added versioning file, removed assemblyIdentity, made snapshot
Removed assemblyIdentity from manifest as it's not 100% necessary and makes it one more version we should change on releases or patches.